### PR TITLE
Lock to nixpkgs with fixed cppcheck.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,16 +131,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1667231093,
-        "narHash": "sha256-RERXruzBEBuf0c7OfZeX1hxEKB+PTCUNxWeB6C1jd8Y=",
+        "lastModified": 1667314267,
+        "narHash": "sha256-AjPX7CvFJTKB0E6z3fcxQqldI6JVVXxSNUnJbRtm7Z8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d40fea9aeb8840fea0d377baa4b38e39b9582458",
+        "rev": "6739decba3546cf6911f056fb38998da386271cd",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "6739decba354",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,8 @@
 {
   inputs = {
     # Main nixpkgs/NixOS package repository, containing most deps.
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    # Temporarily locked for https://github.com/NixOS/nixpkgs/pull/198938
+    nixpkgs.url = "github:nixos/nixpkgs/6739decba354";
 
     # This is Ben Wolsieffer's repo, containing definitions for Gazebo,
     # catkin-pkg, colcon, and numerous other low-level ROS dependencies.


### PR DESCRIPTION
This fixes the build breakage on the most recent snapshot.